### PR TITLE
Fix for issue with flight staying on under certain conditions

### DIFF
--- a/src/main/java/net/croxis/plugins/lift/LiftRedstoneListener.java
+++ b/src/main/java/net/croxis/plugins/lift/LiftRedstoneListener.java
@@ -92,6 +92,8 @@ public class LiftRedstoneListener implements Listener {
 								Player player = (Player) e;
 								if (player.getAllowFlight())
 									plugin.flyers.add(player);
+                                                                else
+                                                                        plugin.flyers.remove(player);
 								if (!player.hasPermission("lift")){
 									elevator.holders.put((LivingEntity) e, e.getLocation());
 									elevator.passengers.remove((LivingEntity) e);


### PR DESCRIPTION
Lift currently works under the assumption that if a player uses an elevator with flight enabled, that player will always have flight enabled (since the player is added to the fly list but never removed).  This is an issue on servers where flight is conditional (as it is on ours, where flight is based on having a specific item equipped).  If a player uses Lift once while they have flight enabled, they will always retain flight after using an elevator from that point forward until a server reset.  This fix simply removes players from the fly list again if they use the elevator without flight enabled.  I've tested it, this does not impact creative mode or always-on flight.
