### PR TITLE
Grab NoCheatPlus from md-5's repo for easier compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	        <id>gravity-repo</id>
 	        <url>http://repo.gravitydevelopment.net/</url>
 	    </repository>
+        <repository>
+            <id>md5-repo</id>
+            <url>http://repo.md-5.net/content/repositories/releases/</url>
+        </repository>
     </repositories>
     <build>
     	<defaultGoal>clean install</defaultGoal>
@@ -204,9 +208,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fr.neatmonster.nocheatplus</groupId>
-            <artifactId>NoCheatPlus</artifactId>
-            <version>3.10.9</version>
+            <groupId>fr.neatmonster</groupId>
+            <artifactId>ncpcore</artifactId>
+            <version>static</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>        


### PR DESCRIPTION
So developers don't have to manually install it by hand.

Also added dependency-reduced-pom.xml to gitignore as it is automatically generated by Maven (and thus not actually needed on the repo)
