### PR TITLE
Fix minecart NPE issue

### DIFF
--- a/src/main/java/net/croxis/plugins/lift/BukkitElevatorManager.java
+++ b/src/main/java/net/croxis/plugins/lift/BukkitElevatorManager.java
@@ -232,8 +232,10 @@ public class BukkitElevatorManager extends ElevatorManager{
 			Entity passenger = holdersIterators.next();
 			if (passenger instanceof Player){
 				removePlayer((Player) passenger, holdersIterators);
-			} else if (passenger instanceof Minecart)
-				((Minecart) passenger).setVelocity(bukkitElevator.getMinecartSpeeds().get(passenger));
+			} else if (passenger instanceof Minecart) {
+				final Vector v = bukkitElevator.getMinecartSpeeds().get(passenger);
+				((Minecart) passenger).setVelocity(v != null ? v : new Vector(0, 0, 0));
+			}
 		}
 		//Fire off redstone signal for arrival
 		Block s = ((BukkitFloor) bukkitElevator.destFloor).getButton().getRelative(BlockFace.UP);


### PR DESCRIPTION
Temporary fix to #143.

This fix will ignore NPE from minecart holder, and give it `(0, 0, 0)` vector for velocity.

The remain problem is that minecart cannot stack together, if I lift a cart and lift another one, it will stuck together (stuck in lifting mode) until I destroy or move the top cart out of the elevator.