### PR TITLE
Add TeleportCause

### DIFF
--- a/src/main/java/net/croxis/plugins/lift/BukkitElevator.java
+++ b/src/main/java/net/croxis/plugins/lift/BukkitElevator.java
@@ -35,6 +35,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Minecart;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.util.Vector;
 
 public class BukkitElevator extends Elevator{
@@ -124,7 +125,7 @@ public class BukkitElevator extends Elevator{
             }
             Location destination = passenger.getLocation();
             destination.setY(destFloor.getY());
-            passenger.teleport(destination);
+            passenger.teleport(destination, TeleportCause.UNKNOWN);
             passenger.setFallDistance(0);
         }
     }


### PR DESCRIPTION
Add TeleportCause to make other plugins know what cause the teleport.
Because Lift is just moving up and down, not really "teleport", so set it to UNKNOWN.